### PR TITLE
Fix bugs in React proxy and PHP sanitization

### DIFF
--- a/APP/PublicCameras.js
+++ b/APP/PublicCameras.js
@@ -9,7 +9,7 @@ const PublicCameras = () => {
     const fetchCameras = async () => {
       try {
         // Fetch HTML via your proxy (not directly from EarthCam)
-        const proxyUrl = 'http://localhost:3001/api/cameras';
+        const proxyUrl = process.env.REACT_APP_PROXY_URL || 'http://localhost:3001/api/cameras';
         const response = await fetch(proxyUrl);
         
         if (!response.ok) {

--- a/APP/README.md
+++ b/APP/README.md
@@ -34,11 +34,11 @@ Cam Scam is a unique OSINT tool designed to scam LLMs and reverse engineer ways 
     npm install
     ```
 
-4. Set up and run the proxy server (make sure the proxy server is running on `http://localhost:3001`):
+4. Set up and run the proxy server (defaults to `http://localhost:3001`):
     ```sh
-    # Example for starting a simple proxy server
-    npm run start-proxy
+    PORT=3001 node server.js
     ```
+    You can change the port by setting the `PORT` environment variable.
 
 5. Start the React application:
     ```sh
@@ -73,7 +73,7 @@ const PublicCameras = () => {
     const fetchCameras = async () => {
       try {
         // Fetch HTML via your proxy (not directly from EarthCam)
-        const proxyUrl = 'http://localhost:3001/api/cameras';
+        const proxyUrl = process.env.REACT_APP_PROXY_URL || 'http://localhost:3001/api/cameras';
         const response = await fetch(proxyUrl);
         
         if (!response.ok) {
@@ -198,7 +198,8 @@ Fetches the HTML content from EarthCam's network page and returns it.
 
 ## Environment Variables
 
-- `PORT`: (Optional) Port number on which the server will run. Defaults to 3000.
+- `PORT`: (Optional) Port number on which the proxy server will run. Defaults to 3001.
+- `REACT_APP_PROXY_URL`: URL used by the React app to fetch camera data. Defaults to `http://localhost:3001/api/cameras`.
 
 ## Code Overview
 
@@ -246,6 +247,6 @@ app.get('/api/cameras', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Proxy running on port ${PORT}`));
 ```

--- a/APP/server.js
+++ b/APP/server.js
@@ -29,5 +29,7 @@ app.get('/api/cameras', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3000;
+// Allow the port to be configured via the PORT environment variable.
+// Default to 3001 so it aligns with the React app configuration.
+const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Proxy running on port ${PORT}`));

--- a/PHP/cam_scam.php
+++ b/PHP/cam_scam.php
@@ -1,32 +1,42 @@
 <?php
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $cameraIP = $_POST["cameraIP"];
-    $protocol = $_POST["protocol"];
+    // Sanitize input to avoid HTML/JS injection
+    $cameraIP = filter_input(INPUT_POST, 'cameraIP', FILTER_SANITIZE_STRING);
+    $protocol = filter_input(INPUT_POST, 'protocol', FILTER_SANITIZE_STRING);
+
+    // Basic validation for allowed protocols
+    $allowed = ["http", "rtsp", "rtmp", "hls"];
+    if (!in_array($protocol, $allowed, true)) {
+        $protocol = "http";
+    }
+
+    $cameraIPEscaped = htmlspecialchars($cameraIP, ENT_QUOTES, 'UTF-8');
     $url = "";
 
     switch ($protocol) {
         case "http":
-            $url = "http://$cameraIP";
+            $url = "http://$cameraIPEscaped";
             break;
         case "rtsp":
-            $url = "rtsp://$cameraIP:554/stream";
+            $url = "rtsp://$cameraIPEscaped:554/stream";
             break;
         case "rtmp":
-            $url = "rtmp://$cameraIP/live/stream";
+            $url = "rtmp://$cameraIPEscaped/live/stream";
             break;
         case "hls":
-            $url = "http://$cameraIP/hls/stream.m3u8";
+            $url = "http://$cameraIPEscaped/hls/stream.m3u8";
             break;
     }
 
-    echo "<h2>Live Feed from Camera at Fairmount Cemetery:</h2>";
-    echo "<video width='600' controls>
-            <source src='$url' type='video/$protocol'>
-            Your browser does not support the video tag.
-          </video>";
+    $protocolEscaped = htmlspecialchars($protocol, ENT_QUOTES, 'UTF-8');
+
+    echo "<h2>Live Feed from Camera:</h2>";
+    echo "<video width='600' controls>\n".
+         "    <source src='$url' type='video/$protocolEscaped'>\n".
+         "    Your browser does not support the video tag.\n".
+         "</video>";
 }
 ?>
-
 <!DOCTYPE html>
 <html>
 <head>
@@ -76,7 +86,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         <form method="post">
             <label for="cameraIP">Camera IP:</label>
             <input type="text" id="cameraIP" name="cameraIP" placeholder="Enter Camera IP" required>
-            
             <label for="protocol">Protocol:</label>
             <select id="protocol" name="protocol" required>
                 <option value="http">HTTP</option>
@@ -84,89 +93,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 <option value="rtmp">RTMP</option>
                 <option value="hls">HLS</option>
             </select>
-            
             <button type="submit">Access</button>
         </form>
     </div>
-    </div>
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form>
-</div>
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-    ====== 
-    </div>
-</body>
-</html>        <label for="cameraPort">Camera Port:</label>
-        <input type="text" id="cameraPort" name="cameraPort" placeholder="Enter Camera Port (e.g., 8080)" required>
-        
-        <label for="cameraUsername">Camera Username:</label>
-        <input type="text" id="cameraUsername" name="cameraUsername" placeholder="Enter Camera Username" required>
-        
-        <label for="cameraPassword">Camera Password:</label>
-        <input type="password" id="cameraPassword" name="cameraPassword" placeholder="Enter Camera Password" required>
-        
-        ====== 
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form
-    </div>
-</body>
-</html>        
-
-        <label for="cameraPort">Camera Port:</label>
-        <input type="text" id="cameraPort" name="cameraPort" placeholder="Enter Camera Port (e.g., 8080)" required>
-        
-        <label for="cameraUsername">Camera Username:</label>
-        <input type="text" id="cameraUsername" name="cameraUsername" placeholder="Enter Camera Username" required>
-        
-        <label for="cameraPassword">Camera Password:</label>
-        <input type="password" id="cameraPassword" name="cameraPassword" placeholder="Enter Camera Password" required>
-        
-        ====== 
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form>
-</div>
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form>
-</div>
-
 </body>
 </html>
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ To install and set up this project, follow these steps:
     npm install
     ```
 
+3. Start the proxy server (defaults to port 3001):
+    ```sh
+    PORT=3001 node APP/server.js
+    ```
+
+   You can configure a different port by setting the `PORT` environment variable.
+
 ## Usage
 
 To use the `PublicCameras` component, import it into your React application and include it in your component tree:
@@ -53,10 +60,14 @@ function App() {
 export default App;
 ```
 
-Run the application:
+Run the application (ensure the proxy server is also running):
 ```sh
 npm start
 ```
+
+The React components use the `REACT_APP_PROXY_URL` environment variable to
+determine where the camera data is fetched from. It defaults to
+`http://localhost:3001/api/cameras` if not specified.
 
 ## Dependencies
 

--- a/__tests__/publicCameras.test.js
+++ b/__tests__/publicCameras.test.js
@@ -1,0 +1,9 @@
+const React = require('react');
+const renderer = require('react-test-renderer');
+const PublicCameras = require('../index.js').default || require('../index.js');
+
+test('PublicCameras renders list', () => {
+  const component = renderer.create(React.createElement(PublicCameras));
+  const tree = component.toJSON();
+  expect(tree).toBeTruthy();
+});

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,0 +1,12 @@
+const request = require('supertest');
+const express = require('express');
+
+// Mock server using the route from server.js
+const app = express();
+app.get('/api/cameras', (req, res) => res.send('<html></html>'));
+
+test('GET /api/cameras returns html', async () => {
+  const res = await request(app).get('/api/cameras');
+  expect(res.statusCode).toBe(200);
+  expect(res.text).toMatch(/<html>/);
+});

--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ const PublicCameras = () => {
 
     useEffect(() => {
         const fetchCameras = async () => {
-            const url = "https://www.earthcam.com/network/";
+            // Fetch via proxy server to avoid CORS issues
+            const url = process.env.REACT_APP_PROXY_URL || 'http://localhost:3001/api/cameras';
 
             try {
-                // Fetch the HTML content of the page
+                // Fetch the HTML content of the page via the proxy
                 const response = await fetch(url);
                 const text = await response.text();
 
@@ -29,7 +30,7 @@ const PublicCameras = () => {
 
         fetchCameras();
     }, []);
-l
+
     return (
         <div>
             <h1>Public Cameras</h1>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "react": "^18.3.1",
+    "react-test-renderer": "^18.3.1",
+    "express": "^4.18.2",
+    "supertest": "^6.3.3"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- align proxy port config between server and React
- sanitize inputs in `cam_scam.php`
- document environment variables in READMEs
- add Jest test skeletons

## Testing
- `npm test` *(fails: jest not found)*

## Summary by Sourcery

Fix security issues in the PHP camera script by sanitizing and validating inputs; unify proxy port settings between the Express server and React client; document environment variables; and configure Jest with basic test suites.

Bug Fixes:
- Sanitize and escape POST inputs in cam_scam.php and enforce allowed protocols to prevent injection.
- Align default proxy port between APP server and React fetch to resolve mismatched configurations.

Enhancements:
- Introduce REACT_APP_PROXY_URL environment variable for dynamic proxy endpoint configuration in React.
- Update package.json to use Jest for testing and add related devDependencies.

Documentation:
- Document PORT and REACT_APP_PROXY_URL environment variables in both APP/README.md and root README.md.

Tests:
- Add Jest test skeletons for the proxy endpoint and the PublicCameras React component.