### PR TITLE
Improve security and proxy defaults

### DIFF
--- a/APP/README.md
+++ b/APP/README.md
@@ -180,9 +180,9 @@ This Node.js server acts as a proxy to fetch camera data from a third-party webs
     node server.js
     ```
 
-2. The server will run on port 3000 by default. You can access the API endpoint at:
+2. The server will run on port **3001** by default. You can access the API endpoint at:
     ```
-    http://localhost:3000/api/cameras
+    http://localhost:3001/api/cameras
     ```
 
 ## API Endpoints
@@ -198,7 +198,7 @@ Fetches the HTML content from EarthCam's network page and returns it.
 
 ## Environment Variables
 
-- `PORT`: (Optional) Port number on which the server will run. Defaults to 3000.
+- `PORT`: (Optional) Port number on which the server will run. Defaults to 3001.
 
 ## Code Overview
 
@@ -246,6 +246,6 @@ app.get('/api/cameras', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Proxy running on port ${PORT}`));
 ```

--- a/APP/server.js
+++ b/APP/server.js
@@ -29,5 +29,7 @@ app.get('/api/cameras', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3000;
+// Allow configuring the port via the PORT environment variable.
+// Default to 3001 so it matches the React component expectations.
+const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Proxy running on port ${PORT}`));

--- a/PHP/README.md
+++ b/PHP/README.md
@@ -14,6 +14,7 @@ The `cam_scam.php` file is a PHP script that allows users to access and view liv
 - **Dynamic URL Construction**: Constructs the appropriate URL based on the selected protocol and the provided camera IP address.
 - **Live Feed Display**: Displays the live video feed within the web interface using HTML5 video elements.
 - **User-Friendly Interface**: Provides a simple and responsive web form for users to input camera details.
+- **Input Sanitization**: Sanitizes all user-provided values to prevent injection attacks.
 
 ## Prerequisites
 

--- a/PHP/cam_scam.php
+++ b/PHP/cam_scam.php
@@ -1,8 +1,18 @@
 <?php
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $cameraIP = $_POST["cameraIP"];
-    $protocol = $_POST["protocol"];
+    // Sanitize user input to prevent injection or malformed HTML.
+    $cameraIP = filter_input(INPUT_POST, "cameraIP", FILTER_SANITIZE_STRING);
+    $protocol = filter_input(INPUT_POST, "protocol", FILTER_SANITIZE_STRING);
     $url = "";
+
+    // Validate allowed protocols
+    $allowed = ["http", "rtsp", "rtmp", "hls"];
+    if (!in_array($protocol, $allowed, true)) {
+        $protocol = "http";
+    }
+
+    // Escape the IP for safe output
+    $cameraIP = htmlspecialchars($cameraIP, ENT_QUOTES, 'UTF-8');
 
     switch ($protocol) {
         case "http":
@@ -19,14 +29,16 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             break;
     }
 
-    echo "<h2>Live Feed from Camera at Fairmount Cemetery:</h2>";
-    echo "<video width='600' controls>
-            <source src='$url' type='video/$protocol'>
-            Your browser does not support the video tag.
-          </video>";
+    $escapedUrl = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
+    $escapedProtocol = htmlspecialchars($protocol, ENT_QUOTES, 'UTF-8');
+
+    echo "<h2>Live Feed from Camera:</h2>";
+    echo "<video width='600' controls>\n".
+         "    <source src='$escapedUrl' type='video/$escapedProtocol'>\n".
+         "    Your browser does not support the video tag.\n".
+         "</video>";
 }
 ?>
-
 <!DOCTYPE html>
 <html>
 <head>
@@ -76,7 +88,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         <form method="post">
             <label for="cameraIP">Camera IP:</label>
             <input type="text" id="cameraIP" name="cameraIP" placeholder="Enter Camera IP" required>
-            
             <label for="protocol">Protocol:</label>
             <select id="protocol" name="protocol" required>
                 <option value="http">HTTP</option>
@@ -84,89 +95,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 <option value="rtmp">RTMP</option>
                 <option value="hls">HLS</option>
             </select>
-            
             <button type="submit">Access</button>
         </form>
     </div>
-    </div>
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form>
-</div>
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-    ====== 
-    </div>
-</body>
-</html>        <label for="cameraPort">Camera Port:</label>
-        <input type="text" id="cameraPort" name="cameraPort" placeholder="Enter Camera Port (e.g., 8080)" required>
-        
-        <label for="cameraUsername">Camera Username:</label>
-        <input type="text" id="cameraUsername" name="cameraUsername" placeholder="Enter Camera Username" required>
-        
-        <label for="cameraPassword">Camera Password:</label>
-        <input type="password" id="cameraPassword" name="cameraPassword" placeholder="Enter Camera Password" required>
-        
-        ====== 
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form
-    </div>
-</body>
-</html>        
-
-        <label for="cameraPort">Camera Port:</label>
-        <input type="text" id="cameraPort" name="cameraPort" placeholder="Enter Camera Port (e.g., 8080)" required>
-        
-        <label for="cameraUsername">Camera Username:</label>
-        <input type="text" id="cameraUsername" name="cameraUsername" placeholder="Enter Camera Username" required>
-        
-        <label for="cameraPassword">Camera Password:</label>
-        <input type="password" id="cameraPassword" name="cameraPassword" placeholder="Enter Camera Password" required>
-        
-        ====== 
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form>
-</div>
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form>
-</div>
-
 </body>
 </html>
+

--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ const PublicCameras = () => {
 
     useEffect(() => {
         const fetchCameras = async () => {
-            const url = "https://www.earthcam.com/network/";
+            // Use the proxy server to avoid CORS issues when fetching
+            // EarthCam data directly from the browser.
+            const url = "http://localhost:3001/api/cameras";
 
             try {
-                // Fetch the HTML content of the page
                 const response = await fetch(url);
                 const text = await response.text();
 
@@ -29,7 +30,7 @@ const PublicCameras = () => {
 
         fetchCameras();
     }, []);
-l
+
     return (
         <div>
             <h1>Public Cameras</h1>


### PR DESCRIPTION
## Summary
- use proxy endpoint in main React component
- default proxy server to port 3001 and update docs
- sanitize inputs and escape output in PHP script

## Testing
- `npm test` *(fails: Error: no test specified)*

## Summary by Sourcery

Improve security of the PHP camera feed script and align proxy defaults by sanitizing inputs, escaping outputs, validating protocols, and standardizing the proxy port to 3001 in both code and documentation

Enhancements:
- Enforce input sanitization and output escaping in PHP to prevent injection and validate protocols
- Switch default proxy server port to 3001 across Node code, React component, and documentation
- Update React component to fetch camera data via the local proxy to avoid CORS issues

Documentation:
- Update APP/README and PHP/README with new default port and input sanitization details