### PR TITLE
Fix port mismatch and sanitize inputs

### DIFF
--- a/APP/README.md
+++ b/APP/README.md
@@ -180,9 +180,9 @@ This Node.js server acts as a proxy to fetch camera data from a third-party webs
     node server.js
     ```
 
-2. The server will run on port 3000 by default. You can access the API endpoint at:
+2. The server will run on port **3001** by default. You can access the API endpoint at:
     ```
-    http://localhost:3000/api/cameras
+    http://localhost:3001/api/cameras
     ```
 
 ## API Endpoints
@@ -198,7 +198,7 @@ Fetches the HTML content from EarthCam's network page and returns it.
 
 ## Environment Variables
 
-- `PORT`: (Optional) Port number on which the server will run. Defaults to 3000.
+- `PORT`: (Optional) Port number on which the server will run. Defaults to **3001**.
 
 ## Code Overview
 
@@ -246,6 +246,6 @@ app.get('/api/cameras', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Proxy running on port ${PORT}`));
 ```

--- a/APP/server.js
+++ b/APP/server.js
@@ -29,5 +29,7 @@ app.get('/api/cameras', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3000;
+// Allow the port to be configured via the PORT environment variable.
+// Default to 3001 so it matches the React app configuration.
+const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Proxy running on port ${PORT}`));

--- a/PHP/cam_scam.php
+++ b/PHP/cam_scam.php
@@ -28,11 +28,34 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     $safeUrl = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
     $safeProtocol = htmlspecialchars($protocol, ENT_QUOTES, 'UTF-8');
+
+    // Map protocol/extension to correct MIME type
+    $mimeTypes = [
+        'mp4' => 'video/mp4',
+        'webm' => 'video/webm',
+        'ogg' => 'video/ogg',
+        'ogv' => 'video/ogg',
+        'mov' => 'video/quicktime',
+        'mkv' => 'video/x-matroska',
+        // Add more as needed
+    ];
+
+    $lowerProtocol = strtolower($protocol);
+    $mimeType = isset($mimeTypes[$lowerProtocol]) ? $mimeTypes[$lowerProtocol] : null;
+
     echo "<h2>Live Feed from Camera:</h2>";
-    echo "<video width='600' controls>\n".
-         "    <source src='$safeUrl' type='video/$safeProtocol'>\n".
-         "    Your browser does not support the video tag.\n".
-         "</video>";
+
+    if ($mimeType) {
+        echo "<video width='600' controls>\n".
+             "    <source src='$safeUrl' type='$mimeType'>\n".
+             "    Your browser does not support the video tag.\n".
+             "</video>";
+    } else {
+        // For unsupported protocols like RTMP/RTSP, suggest using a JS player
+        echo "<p><strong>Protocol '$safeProtocol' is not natively supported by HTML5 video.</strong></p>";
+        echo "<p>Consider using a JavaScript player library such as <a href='https://videojs.com/' target='_blank'>Video.js</a> or <a href='https://github.com/ant-media/StreamApp' target='_blank'>Ant Media StreamApp</a> for RTMP/RTSP streams.</p>";
+        // Optionally, you could include a JS player integration here
+    }
 }
 ?>
 <!DOCTYPE html>

--- a/PHP/cam_scam.php
+++ b/PHP/cam_scam.php
@@ -1,7 +1,14 @@
 <?php
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $cameraIP = $_POST["cameraIP"];
-    $protocol = $_POST["protocol"];
+    // Sanitize user inputs to avoid HTML injection and malformed URLs
+    $cameraIP = filter_var($_POST["cameraIP"], FILTER_SANITIZE_STRING);
+    $protocol = filter_var($_POST["protocol"], FILTER_SANITIZE_STRING);
+
+    // Only allow expected protocols
+    $allowed = ["http", "rtsp", "rtmp", "hls"];
+    if (!in_array($protocol, $allowed)) {
+        $protocol = "http"; // fallback to a safe default
+    }
     $url = "";
 
     switch ($protocol) {
@@ -19,14 +26,15 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             break;
     }
 
-    echo "<h2>Live Feed from Camera at Fairmount Cemetery:</h2>";
-    echo "<video width='600' controls>
-            <source src='$url' type='video/$protocol'>
-            Your browser does not support the video tag.
-          </video>";
+    $safeUrl = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
+    $safeProtocol = htmlspecialchars($protocol, ENT_QUOTES, 'UTF-8');
+    echo "<h2>Live Feed from Camera:</h2>";
+    echo "<video width='600' controls>\n".
+         "    <source src='$safeUrl' type='video/$safeProtocol'>\n".
+         "    Your browser does not support the video tag.\n".
+         "</video>";
 }
 ?>
-
 <!DOCTYPE html>
 <html>
 <head>
@@ -76,7 +84,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         <form method="post">
             <label for="cameraIP">Camera IP:</label>
             <input type="text" id="cameraIP" name="cameraIP" placeholder="Enter Camera IP" required>
-            
             <label for="protocol">Protocol:</label>
             <select id="protocol" name="protocol" required>
                 <option value="http">HTTP</option>
@@ -84,89 +91,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 <option value="rtmp">RTMP</option>
                 <option value="hls">HLS</option>
             </select>
-            
             <button type="submit">Access</button>
         </form>
     </div>
-    </div>
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form>
-</div>
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-    ====== 
-    </div>
-</body>
-</html>        <label for="cameraPort">Camera Port:</label>
-        <input type="text" id="cameraPort" name="cameraPort" placeholder="Enter Camera Port (e.g., 8080)" required>
-        
-        <label for="cameraUsername">Camera Username:</label>
-        <input type="text" id="cameraUsername" name="cameraUsername" placeholder="Enter Camera Username" required>
-        
-        <label for="cameraPassword">Camera Password:</label>
-        <input type="password" id="cameraPassword" name="cameraPassword" placeholder="Enter Camera Password" required>
-        
-        ====== 
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form
-    </div>
-</body>
-</html>        
-
-        <label for="cameraPort">Camera Port:</label>
-        <input type="text" id="cameraPort" name="cameraPort" placeholder="Enter Camera Port (e.g., 8080)" required>
-        
-        <label for="cameraUsername">Camera Username:</label>
-        <input type="text" id="cameraUsername" name="cameraUsername" placeholder="Enter Camera Username" required>
-        
-        <label for="cameraPassword">Camera Password:</label>
-        <input type="password" id="cameraPassword" name="cameraPassword" placeholder="Enter Camera Password" required>
-        
-        ====== 
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form>
-</div>
-        <label for="protocol">Protocol:</label>
-        <select id="protocol" name="protocol" required>
-            <option value="http">HTTP</option>
-            <option value="rtsp">RTSP</option>
-            <option value="rtmp">RTMP</option>
-            <option value="hls">HLS</option>
-        </select>
-        
-        <button type="submit">Access</button>
-    </form>
-</div>
-
 </body>
 </html>
+

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const PublicCameras = () => {
 
     useEffect(() => {
         const fetchCameras = async () => {
-            const url = "https://www.earthcam.com/network/";
+            // Use the proxy server to avoid CORS issues when fetching data
+            const url = "http://localhost:3001/api/cameras";
 
             try {
                 // Fetch the HTML content of the page
@@ -29,7 +30,7 @@ const PublicCameras = () => {
 
         fetchCameras();
     }, []);
-l
+
     return (
         <div>
             <h1>Public Cameras</h1>


### PR DESCRIPTION
## Summary
- use the local proxy in `index.js`
- document and default the proxy server to port 3001
- sanitize form input in `cam_scam.php`
- update docs to reflect new port

## Testing
- `npm test` *(fails: Error: no test specified)*

## Summary by Sourcery

Align the app and proxy to use port 3001, route React requests through the local proxy, strengthen PHP form handling with sanitization and escaping, and update documentation accordingly.

Bug Fixes:
- Align default proxy port from 3000 to 3001 across server and client

Enhancements:
- Implement input sanitization and output escaping in cam_scam.php
- Restrict allowed streaming protocols with a safe default fallback
- Route React camera fetch through the local proxy to avoid CORS
- Remove duplicate and obsolete HTML markup in cam_scam.php

Documentation:
- Update README to reflect default proxy port 3001