### PR TITLE
Fix duplicate proxy URL logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,62 +1,39 @@
 import React, { useEffect, useState } from 'react';
 
 const PublicCameras = () => {
-    const [cameraLinks, setCameraLinks] = useState([]);
+  const [cameraLinks, setCameraLinks] = useState([]);
 
-    useEffect(() => {
-        const fetchCameras = async () => {
+  useEffect(() => {
+    const fetchCameras = async () => {
+      const proxyUrl = process.env.REACT_APP_PROXY_URL || 'http://localhost:3001/api/cameras';
+      try {
+        const response = await fetch(proxyUrl);
+        const text = await response.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(text, 'text/html');
+        const links = doc.querySelectorAll('a.cam_link');
+        const urls = Array.from(links).map(link => link.href);
+        setCameraLinks(urls);
+      } catch (error) {
+        console.error('Error fetching or parsing the page:', error);
+      }
+    };
 
-            // Use the proxy server to avoid CORS issues when fetching data
-            const url = "http://localhost:3001/api/cameras";
+    fetchCameras();
+  }, []);
 
-
-            // Use the proxy server to avoid CORS issues when fetching
-            // EarthCam data directly from the browser.
-            const url = "http://localhost:3001/api/cameras";
-
-            try {
-
-            // Fetch via proxy server to avoid CORS issues
-            const url = process.env.REACT_APP_PROXY_URL || 'http://localhost:3001/api/cameras';
-
-
-            try {
-                // Fetch the HTML content of the page via the proxy
-
-                const response = await fetch(url);
-                const text = await response.text();
-
-                // Parse the HTML content
-                const parser = new DOMParser();
-                const doc = parser.parseFromString(text, 'text/html');
-
-                // Find all camera links on the page
-                const links = doc.querySelectorAll('a.cam_link');
-                const urls = Array.from(links).map(link => link.href);
-
-                // Update state with the camera URLs
-                setCameraLinks(urls);
-            } catch (error) {
-                console.error('Error fetching or parsing the page:', error);
-            }
-        };
-
-        fetchCameras();
-    }, []);
-
-    return (
-        <div>
-            <h1>Public Cameras</h1>
-            <ul>
-                {cameraLinks.map((link, index) => (
-                    <li key={index}>
-                        <a href={link} target="_blank" rel="noopener noreferrer">{link}</a>
-                    </li>
-                ))}
-            </ul>
-        </div>
-    );
+  return (
+    <div>
+      <h1>Public Cameras</h1>
+      <ul>
+        {cameraLinks.map((link, index) => (
+          <li key={index}>
+            <a href={link} target="_blank" rel="noopener noreferrer">{link}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 };
 
 export default PublicCameras;
-


### PR DESCRIPTION
## Summary
- clean up `index.js`
- use one `proxyUrl` value

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e75eef784832bafc6052b0aca3a06

## Summary by Sourcery

Consolidate and simplify proxy URL usage in the PublicCameras component to eliminate redundant declarations and streamline the fetch logic.

Bug Fixes:
- Fix duplicate proxy URL declarations in PublicCameras component.

Enhancements:
- Consolidate fetch logic by using a single `proxyUrl` variable.
- Remove redundant code and clean up index.js formatting.