### PR TITLE
Add Jest configuration and setup script

### DIFF
--- a/FEATURE_PROPOSAL.md
+++ b/FEATURE_PROPOSAL.md
@@ -1,0 +1,17 @@
+# Proposed Features
+
+The following ideas could further enhance the Cam-Scam project:
+
+1. **Automated Data Enrichment**
+   - Integrate third-party OSINT APIs (Shodan, Wigle, etc.) with scheduled data pulls.
+   - Normalize results and store them in a small database for analysis.
+
+2. **Geolocation Visualization**
+   - Render camera locations on an interactive map using Leaflet or Mapbox.
+   - Provide filtering based on data sources or confidence levels.
+
+3. **Extended Test Coverage**
+   - Add tests for the proxy server endpoints and React components.
+   - Include edge cases and error-handling scenarios.
+
+These features would provide a more complete OSINT toolkit and help validate the application's core functionality.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ To install and set up this project, follow these steps:
     cd cam_scam
     ```
 
-2. Install the required dependencies:
+2. Install the required dependencies using the provided setup script:
     ```sh
-    npm install
+    ./setup.sh
     ```
+
+   This script simply runs `npm install` for you.
 
 
 3. Start the proxy server (defaults to port `3001`):
@@ -84,3 +86,13 @@ The project dependencies are managed via `npm`. The `package.json` file includes
 
 - React
 - axios (for API calls)
+
+## Testing
+
+After installing dependencies, run the test suite with:
+
+```sh
+npm test
+```
+
+This project uses Jest for unit testing. All tests can be found in the `__tests__` directory.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    '@babel/preset-react'
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -8,10 +8,19 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
+    "@babel/core": "^7.24.0",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.24.0",
     "react": "^18.3.1",
     "react-test-renderer": "^18.3.1",
     "express": "^4.18.2",
     "supertest": "^6.3.3"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.jsx?$": "babel-jest"
+    }
   },
   "private": true
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Simple setup script for installing npm dependencies
+npm install


### PR DESCRIPTION
## Summary
- configure Jest with Babel
- document setup instructions and testing
- add script to install dependencies
- provide future feature ideas

## Testing
- `npm test` *(fails: jest not installed)*
- `npm install` *(fails: 403 Forbidden; registry unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685e75f0a77c832b9ad9d5f12c5c3a0f

## Summary by Sourcery

Configure Jest with Babel, add a setup script for dependency installation, update project documentation with test and setup instructions, and include a feature proposal document

Enhancements:
- Configure Jest testing with Babel using babel.config.js and jest transform presets

Documentation:
- Update README with setup script usage and Jest test instructions
- Add FEATURE_PROPOSAL.md outlining future enhancement ideas

Tests:
- Add Jest, babel-jest, and Babel presets as devDependencies and configure Jest transform

Chores:
- Add setup.sh script to automate npm dependency installation