### PR TITLE
Add Jest tooling and setup script

### DIFF
--- a/FEATURE_PROPOSAL.md
+++ b/FEATURE_PROPOSAL.md
@@ -1,0 +1,14 @@
+# Feature Proposal
+
+The following enhancements could further improve the Cam-Scam project:
+
+1. **Automated Camera Location Detection**
+   - Integrate a geolocation service to estimate camera location from metadata.
+2. **User Interface Dashboard**
+   - Build a dashboard to browse camera feeds and filter by region.
+3. **Scheduled Data Refresh**
+   - Implement a cron-like task to refresh cached data at regular intervals.
+4. **Docker Support**
+   - Provide Dockerfiles for easy deployment of both frontend and backend.
+
+These features would complement the current functionality by making the tool more user-friendly and easier to deploy.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To install and set up this project, follow these steps:
 
 2. Install the required dependencies:
     ```sh
-    npm install
+    ./setup.sh
     ```
 
 
@@ -77,6 +77,14 @@ npm start
 The React components use the `REACT_APP_PROXY_URL` environment variable to
 determine where the camera data is fetched from. It defaults to
 `http://localhost:3001/api/cameras` if not specified.
+
+### Running Tests
+
+After installing dependencies you can run the test suite with:
+
+```sh
+npm test
+```
 
 ## Dependencies
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    '@babel/preset-react'
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "react": "^18.3.1",
     "react-test-renderer": "^18.3.1",
     "express": "^4.18.2",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "@babel/core": "^7.24.0",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.24.0",
+    "babel-jest": "^29.7.0"
   },
   "private": true
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Simple setup script for installing project dependencies
+npm install


### PR DESCRIPTION
## Summary
- include Babel and Jest utilities in `package.json`
- add babel configuration for Jest
- add a setup script to install packages
- document setup script and test instructions
- propose future features for the project

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7727fd38832bb03f8f3592cc305e

## Summary by Sourcery

Set up Jest testing environment with Babel support, add a setup script, update documentation for test execution, and propose future project enhancements.

New Features:
- Add Babel and Jest dependencies to enable testing with Jest

Enhancements:
- Introduce setup.sh script for streamlined installation of project dependencies

Documentation:
- Update README with instructions for running the test suite
- Add FEATURE_PROPOSAL.md outlining potential future enhancements

Tests:
- Configure Jest via babel.config.js and enable test execution with npm test