### PR TITLE
Fix server credentials

### DIFF
--- a/APP/server.js
+++ b/APP/server.js
@@ -9,8 +9,7 @@ const { identifyPhoneNumber } = require('./services/phoneService');
 const app = express();
 app.use(cors());
 
-const SHODAN_API_KEY = 'kXbnhyS8FUXZIm2ZNTHISmiYP8IHCUVD';
-const WIGLE_API_KEY = 'kXbnhyS8FUXZIm2ZNTHISmiYP8IHCUVD';
+const SHODAN_API_KEY = process.env.SHODAN_API_KEY || '';
 
 // Cache TTL in seconds
 const CACHE_TTL = 300;
@@ -71,10 +70,9 @@ app.get('/api/shodan', async (req, res) => {
   }
 });
 
-const basicAuth = require('basic-auth');
 
-const WIGLE_USERNAME = 'kXbnhyS8FUXZIm2ZNTHISmiYP8IHCUVD'; // Assuming username is the key provided
-const WIGLE_PASSWORD = 'kXbnhyS8FUXZIm2ZNTHISmiYP8IHCUVD'; // Assuming password is the same key for now
+const WIGLE_USERNAME = process.env.WIGLE_USERNAME || '';
+const WIGLE_PASSWORD = process.env.WIGLE_PASSWORD || '';
 
 // Wigle API endpoint with caching
 app.get('/api/wigle', async (req, res) => {


### PR DESCRIPTION
## Summary
- load API keys and credentials from environment variables
- clean up Wigle imports

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f590db030832b9811c0fd1deb4e43

## Summary by Sourcery

Load Shodan and Wigle credentials from environment variables, replacing hard-coded values and removing unused imports

Enhancements:
- Retrieve Shodan API key and Wigle username/password from environment variables

Chores:
- Remove hard-coded WIGLE_API_KEY constant and basic-auth dependency import